### PR TITLE
ci: Fix slicer-apidocs-builder not working on Python 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /usr/src/apidocs
     docker:
-      - image: python:2.7.13
+      - image: python:3.9.9
     steps:
       - checkout
       - run:


### PR DESCRIPTION
Dependencies of [slicer-apidocs-builder](https://github.com/Slicer/slicer-apidocs-builder) are now Python 3 only so building this package on a Python 2 image is not going to work.

A failed usage of the python package can be found in failed run https://app.circleci.com/pipelines/github/Slicer/apidocs.slicer.org/2407/workflows/8de9b226-90d5-43d4-ac7e-1d4a6c630fcd/jobs/6737