### PR TITLE
fix(doxygen-build-and-publish): Update Doxygen to 1.13 to fix function grouping issues

### DIFF
--- a/.github/workflows/doxygen-build-and-publish.yml
+++ b/.github/workflows/doxygen-build-and-publish.yml
@@ -137,7 +137,7 @@ jobs:
 
       - uses: ssciwr/doxygen-install@527824132256e685f03ec80c0851fe79937eb1d6 # v1.6.3
         with:
-          version: "1.10.0"
+          version: "1.13.0"
 
       # The "dot" binary is provided by Graphviz
       - uses: ts-graphviz/setup-graphviz@b1de5da23ed0a6d14e0aeee8ed52fdd87af2363c # v2.0.2


### PR DESCRIPTION
This commit upgrades Doxygen from version 1.10 to 1.13, addressing function grouping issues.  Version 1.13 includes commit doxygen/doxygen@be30c551c (`issue #11095 Grouping and deriving from a template class leads to "not documented" members.`). This update should resolve Slicer/Slicer#8298.